### PR TITLE
feat: migrate application stacks to GitStack

### DIFF
--- a/infrastructure/stage/stateful-application-stack.ts
+++ b/infrastructure/stage/stateful-application-stack.ts
@@ -3,10 +3,11 @@ import { Construct } from 'constructs';
 import { StatefulApplicationStackConfig } from './interfaces';
 import { buildSsmParameters } from './ssm';
 import { buildSchemas } from './event-schemas';
+import { GitStack } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 export type StatefulApplicationStackProps = cdk.StackProps & StatefulApplicationStackConfig;
 
-export class StatefulApplicationStack extends cdk.Stack {
+export class StatefulApplicationStack extends GitStack {
   constructor(scope: Construct, id: string, props: StatefulApplicationStackProps) {
     super(scope, id, props);
 

--- a/infrastructure/stage/stateless-application-stack.ts
+++ b/infrastructure/stage/stateless-application-stack.ts
@@ -11,11 +11,12 @@ import { buildAllEventRules } from './event-rules';
 import { buildAllEventBridgeTargets } from './event-targets';
 import { NagSuppressions } from 'cdk-nag';
 import { StageName } from '@orcabus/platform-cdk-constructs/shared-config/accounts';
+import { GitStack } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 export type StatelessApplicationStackProps = StatelessApplicationStackConfig & cdk.StackProps;
 
 // Stateless Application Stack
-export class StatelessApplicationStack extends cdk.Stack {
+export class StatelessApplicationStack extends GitStack {
   public readonly stageName: StageName;
 
   constructor(scope: Construct, id: string, props: StatelessApplicationStackProps) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@aws-cdk/aws-lambda-python-alpha": "2.240.0-alpha.0",
     "@aws-cdk/aws-pipes-alpha": "2.240.0-alpha.0",
     "@aws-cdk/aws-pipes-sources-alpha": "2.240.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "1.2.5",
+    "@orcabus/platform-cdk-constructs": "1.7.2",
     "aws-cdk-lib": "^2.244.0",
     "constructs": "^10.6.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 2.240.0-alpha.0
         version: 2.240.0-alpha.0(@aws-cdk/aws-pipes-alpha@2.240.0-alpha.0(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.2.5
-        version: 1.2.5(@aws-cdk/aws-lambda-python-alpha@2.240.0-alpha.0(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.7.2
+        version: 1.7.2(@aws-cdk/aws-lambda-python-alpha@2.240.0-alpha.0(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.244.0
         version: 2.244.0(constructs@10.6.0)
@@ -456,12 +456,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@orcabus/platform-cdk-constructs@1.2.5':
-    resolution: {integrity: sha512-l+nFkR7yPHRkHHdU/I3yhvPqoICKmjwYz2bQseuJPdW/Zfb4Qtncjr6ICYDmcwRgZmXK7W4KRqOHZCYSZ4uktA==}
+  '@orcabus/platform-cdk-constructs@1.7.2':
+    resolution: {integrity: sha512-oayS7Cpe94ZrwLIzKgDuHC1uOeN8r88CpgJDo3NIOyLp4wVCgAtTFPA+GL/mAL43PICLC++rfQcUFcgbx60IhQ==}
     peerDependencies:
-      '@aws-cdk/aws-lambda-python-alpha': ^2.233.0-alpha.0
-      aws-cdk-lib: ^2.233.0
-      constructs: ^10.4.2
+      '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
+      aws-cdk-lib: ^2.244.0
+      constructs: ^10.6.0
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2333,7 +2333,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.2.5(@aws-cdk/aws-lambda-python-alpha@2.240.0-alpha.0(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.7.2(@aws-cdk/aws-lambda-python-alpha@2.240.0-alpha.0(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.240.0-alpha.0(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib: 2.244.0(constructs@10.6.0)


### PR DESCRIPTION
Extend both StatelessApplicationStack and StatefulApplicationStack from GitStack instead of cdk.Stack.

This adds a GitCommitId CloudFormation output to each deployed stack, enabling tracking of which commit is currently deployed in each environment.

Also bumps `@orcabus/platform-cdk-constructs` from 1.2.5 to 1.7.2 as GitStack was not available in the older version.

## Changes
- `infrastructure/stage/stateless-application-stack.ts`: extends GitStack
- `infrastructure/stage/stateful-application-stack.ts`: extends GitStack
- `package.json`: bump platform-cdk-constructs 1.2.5 → 1.7.2
- `pnpm-lock.yaml`: lockfile update