### PR TITLE
chore: harmonise CI workflows with other pipeline services

### DIFF
--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -1,0 +1,285 @@
+name: pnpm Audit & Auto-fix
+
+on:
+  schedule:
+    # Run daily at 00:05 UTC (10:05 AEST) — offset to avoid caching delays on CVE publication
+    - cron: '5 0 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  audit-and-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+
+      - run: corepack enable
+
+      - name: Install yq
+        uses: mikefarah/yq@v4.53.3
+
+      - name: Check existing open audit PRs
+        id: check-existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find open PRs from previous audit runs
+          EXISTING_PR=$(gh pr list \
+            --state open \
+            --search "chore: fix pnpm audit vulnerabilities in:title" \
+            --json number,headRefName \
+            --jq '.[0] // empty')
+
+          if [[ -z "$EXISTING_PR" ]]; then
+            echo "existing_pr=false" >> "$GITHUB_OUTPUT"
+            echo "No existing audit PR found."
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+          PR_BRANCH=$(echo "$EXISTING_PR" | jq -r '.headRefName')
+          echo "existing_pr=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "pr_branch=${PR_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Found existing audit PR #${PR_NUMBER} on branch ${PR_BRANCH}"
+
+      - name: Test if existing PR still resolves audit
+        id: test-existing
+        if: steps.check-existing.outputs.existing_pr == 'true'
+        run: |
+          PR_BRANCH="${{ steps.check-existing.outputs.pr_branch }}"
+
+          # Checkout the PR branch and test audit
+          git fetch origin "$PR_BRANCH"
+          git checkout "$PR_BRANCH"
+
+          pnpm install --frozen-lockfile --ignore-scripts
+
+          if pnpm audit > /dev/null 2>&1; then
+            echo "pr_still_valid=true" >> "$GITHUB_OUTPUT"
+            echo "Existing PR still passes audit — nothing to do."
+          else
+            echo "pr_still_valid=false" >> "$GITHUB_OUTPUT"
+            echo "Existing PR no longer resolves all vulnerabilities."
+          fi
+
+      - name: Close stale PR
+        if: |
+          steps.check-existing.outputs.existing_pr == 'true' &&
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.check-existing.outputs.pr_number }}"
+          PR_BRANCH="${{ steps.check-existing.outputs.pr_branch }}"
+
+          gh pr close "$PR_NUMBER" \
+            --comment "Closing: this PR no longer resolves all current audit vulnerabilities. A new PR will be generated." \
+            --delete-branch
+
+          echo "Closed stale PR #${PR_NUMBER} and deleted branch ${PR_BRANCH}."
+
+      - name: Re-checkout main
+        if: |
+          steps.check-existing.outputs.existing_pr != 'true' ||
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        run: |
+          git checkout main
+          git pull origin main
+
+      - name: Install dependencies
+        id: install
+        if: |
+          steps.check-existing.outputs.existing_pr != 'true' ||
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Run pnpm audit
+        id: audit
+        if: |
+          steps.check-existing.outputs.existing_pr != 'true' ||
+          steps.test-existing.outputs.pr_still_valid == 'false'
+        run: |
+          set -o pipefail
+          if pnpm audit 2>&1 | tee audit-output.txt; then
+            echo "has_vulnerabilities=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_vulnerabilities=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attempt pnpm upgrade
+        id: upgrade
+        if: steps.audit.outputs.has_vulnerabilities == 'true'
+        run: |
+          set -o pipefail
+          # Try a standard upgrade to resolve vulnerabilities
+          # --ignore-scripts avoids running lifecycle hooks (e.g. prepare: pre-commit install)
+          pnpm upgrade --ignore-scripts
+
+          # Re-run audit to see if upgrade resolved issues
+          if pnpm audit 2>&1 | tee audit-after-upgrade.txt; then
+            echo "upgrade_fixed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "upgrade_fixed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attempt pnpm audit --fix=override
+        id: audit-fix
+        if: steps.upgrade.outputs.upgrade_fixed == 'false'
+        run: |
+          set -o pipefail
+          # Remove existing overrides to prevent stale/conflicting ranges accumulating
+          if [ -f pnpm-workspace.yaml ]; then yq -i 'del(.overrides)' pnpm-workspace.yaml; fi
+
+          # Reinstall to regenerate lockfile without old overrides
+          pnpm install --no-frozen-lockfile --ignore-scripts
+
+          # Use pnpm audit --fix=override to add fresh overrides for vulnerable transitive deps
+          pnpm audit --fix=override 2>&1 | tee audit-fix-output.txt || true
+
+          # Reinstall with the new overrides
+          pnpm install --no-frozen-lockfile --ignore-scripts
+
+          # Verify the fix resolved the issues
+          if pnpm audit 2>&1 | tee audit-after-fix.txt; then
+            echo "audit_fix_resolved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "audit_fix_resolved=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine fix method
+        id: fix-method
+        if: |
+          steps.upgrade.outputs.upgrade_fixed == 'true' ||
+          steps.audit-fix.outputs.audit_fix_resolved == 'true'
+        run: |
+          if [[ "${{ steps.upgrade.outputs.upgrade_fixed }}" == "true" ]]; then
+            echo "method=pnpm upgrade" >> "$GITHUB_OUTPUT"
+          else
+            echo "method=pnpm audit --fix=override" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tracking issue
+        id: create-issue
+        if: |
+          steps.upgrade.outputs.upgrade_fixed == 'true' ||
+          steps.audit-fix.outputs.audit_fix_resolved == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FIX_METHOD="${{ steps.fix-method.outputs.method }}"
+
+          ISSUE_URL=$(gh issue create \
+            --title "Security: pnpm audit vulnerabilities ($(date +%Y-%m-%d))" \
+            --label "security,dependencies" \
+            --body "## Security Audit Vulnerabilities
+
+          The daily \`pnpm audit\` workflow detected vulnerabilities and was able to resolve them automatically.
+
+          **Fix method:** \`${FIX_METHOD}\`
+
+          A PR has been created to address these vulnerabilities. This issue will be closed when the PR is merged.")
+
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+          echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR with verified commit
+        if: |
+          steps.upgrade.outputs.upgrade_fixed == 'true' ||
+          steps.audit-fix.outputs.audit_fix_resolved == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: chore/pnpm-audit-fix-${{ github.run_id }}
+          add-paths: |
+            package.json
+            pnpm-workspace.yaml
+            pnpm-lock.yaml
+          commit-message: 'chore: fix security vulnerabilities via ${{ steps.fix-method.outputs.method }}'
+          title: 'chore: fix pnpm audit vulnerabilities (${{ github.run_id }})'
+          body: |
+            ## Security Audit Auto-fix
+
+            This PR was automatically generated by the daily `pnpm audit` workflow.
+
+            **Fix method:** `${{ steps.fix-method.outputs.method }}`
+
+            Closes #${{ steps.create-issue.outputs.issue_number }}
+
+            ### What happened
+            - `pnpm audit` detected vulnerabilities in dependencies
+            - The workflow attempted to resolve them automatically
+            - All vulnerabilities were resolved
+
+            ### Next steps
+            - Review the dependency changes
+            - Ensure CI passes
+            - Merge when satisfied
+          labels: security,dependencies
+          delete-branch: true
+          sign-commits: true
+
+      - name: Create issue for unresolved vulnerabilities
+        if: |
+          steps.audit.outputs.has_vulnerabilities == 'true' &&
+          steps.upgrade.outputs.upgrade_fixed != 'true' &&
+          steps.audit-fix.outputs.audit_fix_resolved != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if there's already an open issue for unresolved audit vulnerabilities
+          EXISTING_ISSUE=$(gh issue list \
+            --state open \
+            --search "Security: unresolved pnpm audit vulnerabilities in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [[ -n "$EXISTING_ISSUE" ]]; then
+            # Add a comment with today's audit output to the existing issue
+            AUDIT_OUTPUT=$(cat audit-output.txt | head -100)
+            gh issue comment "$EXISTING_ISSUE" \
+              --body "## Daily audit re-check ($(date +%Y-%m-%d))
+
+          Vulnerabilities are still unresolved. Current audit output:
+
+          \`\`\`
+          ${AUDIT_OUTPUT}
+          \`\`\`"
+            echo "Updated existing issue #${EXISTING_ISSUE} with today's audit output."
+            exit 0
+          fi
+
+          AUDIT_OUTPUT=$(cat audit-output.txt | head -100)
+
+          gh issue create \
+            --title "Security: unresolved pnpm audit vulnerabilities ($(date +%Y-%m-%d))" \
+            --label "security,dependencies" \
+            --body "## Unresolved Security Vulnerabilities
+
+          The daily \`pnpm audit\` workflow found vulnerabilities that could not be automatically resolved.
+
+          ### Remediation attempts
+          1. ❌ \`pnpm upgrade\` — did not resolve all issues
+          2. ❌ \`pnpm audit --fix=override\` — did not resolve all issues
+
+          ### Audit output
+          \`\`\`
+          ${AUDIT_OUTPUT}
+          \`\`\`
+
+          ### Manual action required
+          - Review the vulnerable packages above
+          - Check if upstream fixes are available
+          - Consider replacing packages if no fix is forthcoming
+          - If the vulnerability is acceptable (e.g. dev-only, not exploitable in context), document the justification and close this issue"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,34 +1,24 @@
 name: Pull Request Tests
 
 on:
-  merge_group:
+  merge_group: {}
   pull_request:
-    paths-ignore:
-      # The ignore only works only if changes to the main branch only include the following files.
-      # So if the commit only contain .md changes but the PR change contain more, the ignore fails
-      # https://github.com/actions/runner/issues/2324#issuecomment-1703345084
-      - '**.md'
-      - '**.svg'
-      - '**.drawio'
-      - '**.png'
     types:
       - opened
       - reopened
       - synchronize
       - ready_for_review
-      - auto_merge_enabled
     branches:
       - main
 
 permissions: read-all
 
 # Actions Used (please keep this documented here as added)
-#  https://github.com/marketplace/actions/checkout
-#  https://github.com/marketplace/actions/setup-python
-#  https://github.com/marketplace/actions/trufflehog-oss
-#  https://github.com/marketplace/actions/checkout
-#  https://github.com/marketplace/actions/cache
-#  https://github.com/actions-rust-lang/setup-rust-toolchain
+#  https://github.com/marketplace/actions/checkout (v7)
+#  https://github.com/marketplace/actions/setup-node-js-environment (v7)
+#  https://github.com/marketplace/actions/setup-pnpm (v6)
+#  https://github.com/marketplace/actions/trufflehog-oss (v3.96.0)
+#  https://github.com/dorny/paths-filter (v4)
 
 jobs:
   pre-commit-lint-security:
@@ -36,15 +26,15 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'pnpm'
 
       - run: corepack enable
@@ -62,7 +52,7 @@ jobs:
           pip3 install pre-commit detect-secrets black ggshield
 
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.34.0
+        uses: trufflesecurity/trufflehog@v3.96.0
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
@@ -77,17 +67,48 @@ jobs:
         run: |
           make check
 
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.ts'
+              - '**/*.sh'
+              - '**/*.py'
+              - '**/package.json'
+              - '**/pnpm-lock.yaml'
+              - 'infrastructure/**'
+              - 'app/**'
+              - 'test/**'
+              - 'Makefile'
+              - '.github/**'
+              - 'cdk.json'
+              - 'tsconfig.json'
+              - 'jest.config.*'
   test-iac:
     runs-on: ubuntu-22.04-arm
-    if: ${{ !github.event.pull_request.draft }}
+    # Excluded for template-service-base which has no application code to test
+    if: >-
+      !github.event.pull_request.draft &&
+      github.repository != 'OrcaBus/template-service-base' &&
+      needs.check-changes.outputs.should_test == 'true'
+    needs: check-changes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'pnpm'
 
       - run: corepack enable
@@ -95,3 +116,25 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm test
+
+  # This is the job you set as "required" in branch protection
+  ci-gate:
+    runs-on: ubuntu-latest
+    needs: [pre-commit-lint-security, check-changes, test-iac]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.pre-commit-lint-security.result }}" != "success" && "${{ needs.pre-commit-lint-security.result }}" != "skipped" ]]; then
+            echo "Lint/security checks did not succeed (result: ${{ needs.pre-commit-lint-security.result }})"
+            exit 1
+          fi
+          if [[ "${{ needs.check-changes.result }}" != "success" ]]; then
+            echo "Change detection did not succeed (result: ${{ needs.check-changes.result }})"
+            exit 1
+          fi
+          if [[ "${{ needs.test-iac.result }}" != "success" && "${{ needs.test-iac.result }}" != "skipped" ]]; then
+            echo "Tests did not succeed (result: ${{ needs.test-iac.result }})"
+            exit 1
+          fi
+          echo "CI passed (tests passed or were skipped)"


### PR DESCRIPTION
## Summary

Brings the CI workflows in this repo in line with the standardized versions used across all other OrcaBus pipeline manager services.

## Changes

### pr-tests.yml
- Bump actions: checkout v4→v7, setup-node v4→v7, action-setup v4→v6
- Bump Node version: 20.x → 24.x
- Bump TruffleHog: v3.34.0 → v3.96.0
- Remove `paths-ignore` and `auto_merge_enabled` trigger type
- Add `check-changes` job using `dorny/paths-filter` to skip tests when only non-code files change
- Make `test-iac` conditional on actual code changes
- Add `ci-gate` job as a single required status check for branch protection

### pnpm-audit.yml (new)
- Daily schedule (00:05 UTC) + manual dispatch
- Checks for existing open audit PRs and validates/closes stale ones
- Attempts `pnpm upgrade` first, falls back to `pnpm audit --fix=override`
- Auto-creates PRs with signed commits and tracking issues
- Creates issues for vulnerabilities that cannot be auto-resolved